### PR TITLE
Arrumando função mockFindOne

### DIFF
--- a/tests/mock/models/index.js
+++ b/tests/mock/models/index.js
@@ -38,24 +38,18 @@ const mockCreate = (Instance, data) => {
 
 const mockFindOne = (Instance, where) => {
   if (!where) {
-    return Instance[0];
+        return Instance[0];
   }
 
-  const entries = Object.entries(where);
-  let result;
+  const whereFields = Object.keys(where);
 
-  entries.forEach((entry) => {
-    const [key, value] = [entry[0], entry[1]];
-
-    const index = Instance
-      .findIndex((item) => !!item[key] && item[key] === value);
-    if (index !== -1) {
-      result = Instance[index];
-    }
+  const result = Instance.filter(item => {
+    const onlyMatch = whereFields.map( key => item[key] === where[key]);
+    return onlyMatch.filter(v=>v).length === whereFields.length;
   });
 
-  return result;
-};
+  return result[0];
+}
 
 /*
   No nosso caso, os modelos aqui precisam de 3 funções principais


### PR DESCRIPTION
A função mockFindOne recebe o parâmetro `where` e a lógica do código atual retorna como se fosse um OR quando tem 2 parâmetros no `where`. Deveria funcionar como AND.

Este PR altera esse mockFindOne para o `where` funcionar como AND.

Com o código Atual:
Para `Users.json` dessa forma:
```
[
  {
    "id": 1,
    "username": "Saul Reixas",
    "password": "tocasaul"
  },
  {
    "id": 2,
    "username": "Kássia Lemmer",
    "password": "kelimmar"
  },
{
    "id": 3,
    "username": "Mim Taia",
    "password": "tocasaul"
  },
]
```

e quando o where for:
```
where : {
    "username": "Mim Taia",
    "password": "tocasaul"
}
```

a função retorna a pessoa usuária de `id=1`, ao invés de retornar a pessoa usuária de `id=3`, pois ele encontra o `password` igual no `id=1`. Considera como `WHERE username = "Mim Taia" OR password = "tocasaul"` e a pessoa usuária de `id=1` atende essa cláusula WHERE.
