### PR TITLE
fix: remove npm start do docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
     volumes:
       - ./:/app
     working_dir: /app
-    command: npm start # note que o containter já vai iniciar a aplicação
     # As duas opções abaixo correspondem ao -it
     tty: true # -t
     stdin_open: true #-i 


### PR DESCRIPTION
O README diz para a pessoa estudante iniciar o container manualmente pelo terminal do container.
